### PR TITLE
Fix type creation for wsdls with anonymous complex types

### DIFF
--- a/src/node-soap/node-soap-resolver.ts
+++ b/src/node-soap/node-soap-resolver.ts
@@ -244,7 +244,7 @@ export class NodeSoapWsdlResolver {
             fields: null,
         };
 
-        // resolve bindings (field types, base type) after type has been registered to resolve circular dependencies
+        // resolve bindings (field types, base type)
         const bodyTypeDefinition: XsdTypeDefinition = xsdFieldDefinition.children ? xsdFieldDefinition.children[0] : undefined;
         if (bodyTypeDefinition) {
             this.resolveTypeBody(soapType, namespace, bodyTypeDefinition);

--- a/src/node-soap/node-soap-resolver.ts
+++ b/src/node-soap/node-soap-resolver.ts
@@ -236,7 +236,10 @@ export class NodeSoapWsdlResolver {
         const ownerStringForLog = `field '${xsdFieldDefinition.$name}' of soap type '${parentSoapType.name}'`;
         this.debug(() => `resolving anonymous type for ${ownerStringForLog} from namespace '${namespace}'`);
 
-        const generatedTypeName = `${parentSoapType.name}_${capitalizeFirstLetter(xsdFieldDefinition.$name)}`;
+        let generatedTypeName = `${parentSoapType.name}_${capitalizeFirstLetter(xsdFieldDefinition.$name)}`;
+        while (!!this.findXsdTypeDefinition(namespace, generatedTypeName)) {
+            generatedTypeName = generatedTypeName + "_";
+        }
 
         const soapType: SoapObjectType = {
             name: generatedTypeName,

--- a/src/node-soap/node-soap-resolver.ts
+++ b/src/node-soap/node-soap-resolver.ts
@@ -33,8 +33,9 @@ type XsdExtension = { name: 'extension'; $base: string; children: XsdSequence[] 
 type XsdFieldDefinition = {
     $name: string;
     $targetNamespace: string;
-    $type: string;
+    $type: string|undefined;
     $maxOccurs?: 'unbounded' | string;
+    children: XsdTypeDefinition[]|undefined;
 };
 
 export class NodeSoapWsdlResolver {
@@ -230,6 +231,30 @@ export class NodeSoapWsdlResolver {
         }
     }
 
+    private resolveAnonymousTypeToSoapType(xsdFieldDefinition: XsdFieldDefinition, parentSoapType: SoapObjectType): SoapType {
+        const namespace = xsdFieldDefinition.$targetNamespace;
+        const ownerStringForLog = `field '${xsdFieldDefinition.$name}' of soap type '${parentSoapType.name}'`;
+        this.debug(() => `resolving anonymous type for ${ownerStringForLog} from namespace '${namespace}'`);
+
+        const generatedTypeName = `${parentSoapType.name}_${capitalizeFirstLetter(xsdFieldDefinition.$name)}`;
+
+        const soapType: SoapObjectType = {
+            name: generatedTypeName,
+            base: null,
+            fields: null,
+        };
+
+        // resolve bindings (field types, base type) after type has been registered to resolve circular dependencies
+        const bodyTypeDefinition: XsdTypeDefinition = xsdFieldDefinition.children ? xsdFieldDefinition.children[0] : undefined;
+        if (bodyTypeDefinition) {
+            this.resolveTypeBody(soapType, namespace, bodyTypeDefinition);
+            this.debug(() => `resolved namespace: '${namespace}', typeName: '${generatedTypeName}' to object type '${inspect(soapType, false, 3)}'`);
+        } else {
+            this.warn(() => `cannot determine type definition for soap type '${generatedTypeName}', leaving fields empty`);
+        }
+        return soapType;
+    }
+
     private findXsdTypeDefinition(namespace: string, typeName: string): XsdTypeDefinition {
         return this.wsdl.findSchemaObject(namespace, typeName)
     }
@@ -259,11 +284,17 @@ export class NodeSoapWsdlResolver {
         }
 
         const soapFields: SoapField[] = fields.map((field: XsdFieldDefinition) => {
+            let type;
+            if (field.$type) {
+                type = this.resolveWsdlNameToSoapType(field.$targetNamespace, withoutNamespace(field.$type), `field '${field.$name}' of soap type '${soapType.name}'`);
+            } else {
+                type = this.resolveAnonymousTypeToSoapType(field, soapType);
+            }
             return {
                 name: field.$name,
-                type: this.resolveWsdlNameToSoapType(field.$targetNamespace, withoutNamespace(field.$type), `field '${field.$name}' of soap type '${soapType.name}'`),
-                isList: !!field.$maxOccurs && field.$maxOccurs === 'unbounded',
-            }
+                type,
+                isList: !!field.$maxOccurs && field.$maxOccurs === 'unbounded'
+            };
         });
 
         // @todo in XSD it is possible to inherit a type from a primitive ... may have to handle this
@@ -311,4 +342,8 @@ function parseWsdlFieldName(wsdlFieldName: string): { name: string, isList: bool
             isList: false,
         }
     }
+}
+
+function capitalizeFirstLetter(value: string) {
+    return value.charAt(0).toUpperCase() + value.substring(1);
 }


### PR DESCRIPTION
@sevenclev, I have added some logic to handle anonymous complex types. Instead of resolving them by name, they have to be created directly using the xsdFieldDefinition.

I've got a spec running here locally which generates the types correctly. @Yogu has added an xsd excerpt in https://github.com/sevenclev/node-soap-graphql/issues/2#issuecomment-1239142328:

```
<xs:complexType name="getDocumentCategoriesResponseDTO">
    <xs:complexContent>
        <xs:extension base="tns:abstractResponseDTO">
            <xs:sequence>
                <xs:element name="categories" minOccurs="0">
                    <xs:complexType>
                        <xs:sequence>
                            <xs:element name="category" type="tns:lisExpMODocumentCategoryDTO" minOccurs="0"
                                        maxOccurs="unbounded"/>
                        </xs:sequence>
                    </xs:complexType>
                </xs:element>
            </xs:sequence>
        </xs:extension>
    </xs:complexContent>
</xs:complexType>
```
The following GraphQL schema is now generated:

```
...
type GetDocumentCategoriesResponseDTO implements iAbstractResponseDTO {
  categories: GetDocumentCategoriesResponseDTO_Categories
  hasErrors: Boolean
  hasOnlyRetryableErrors: Boolean
  hasWarnings: Boolean
  messages: [ResponseMessageDTO]
}

type GetDocumentCategoriesResponseDTO_Categories {
  category: [LisExpMODocumentCategoryDTO]
}
...
```
Unfortunately, I don't have a non-NDA-relevant example of a WSDL which can add to the specs. I don't know if I'm allowed to push my spec. Perhaps we can add a spec for a WSDL with anonymous complex types later.


Fixes #2