### PR TITLE
Update packages in order to support graphql 15 and 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,28 +4,65 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/graphql": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.12.7.tgz",
-      "integrity": "sha1-OS5G1sG8631owRcjPOp4fd5yeAw=",
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.61.tgz",
-      "integrity": "sha1-0pkTbOVLyvGrqkpIf55L7faw05M=",
-      "dev": true
-    },
-    "@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-      "dev": true
-    },
-    "@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha1-mqMMBNshKpoGSdaub9UKzMQHSKE=",
+      "version": "14.18.29",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/@types/node/-/node-14.18.29.tgz",
+      "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
       "dev": true
     },
     "@xmldom/xmldom": {
@@ -34,19 +71,22 @@
       "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
       "dev": true
     },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
+    "acorn": {
+      "version": "8.8.0",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true
     },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "assertion-error": {
@@ -96,12 +136,6 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
-      "dev": true
-    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -125,53 +159,10 @@
         "check-error": "^1.0.2"
       }
     },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commander": {
@@ -190,6 +181,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
       "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "debug": {
@@ -273,18 +270,18 @@
       }
     },
     "graphql": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
-      "integrity": "sha1-EWaEWLvigmHA3LbiZfUVunn2zgc=",
-      "dev": true,
-      "requires": {
-        "iterall": "1.1.3"
-      }
+      "version": "16.6.0",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "dev": true
     },
-    "graphql-iso-date": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.3.0.tgz",
-      "integrity": "sha1-y+Q0tB4DXoBjOBIbGytQmg9yu4A="
+    "graphql-scalars": {
+      "version": "1.18.0",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/graphql-scalars/-/graphql-scalars-1.18.0.tgz",
+      "integrity": "sha512-XrMwSim4xJ5n1UdT3YMJh9uT3oB/th5jR5bIMJvYxmgq/rGDkfXNtCRSL/+dLMHxGM0thYPfIZDua1+aQlKBMA==",
+      "requires": {
+        "tslib": "~2.4.0"
+      }
     },
     "growl": {
       "version": "1.10.3",
@@ -304,15 +301,6 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "homedir-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-      "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
-      "dev": true,
-      "requires": {
-        "parse-passwd": "^1.0.0"
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -329,12 +317,6 @@
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
-    "iterall": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-      "integrity": "sha1-HLv/liBAVt3mZW4u0uIibQ5tcsk=",
-      "dev": true
-    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -343,8 +325,8 @@
     },
     "make-error": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "minimatch": {
@@ -404,12 +386,6 @@
         "wrappy": "1"
       }
     },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -464,32 +440,10 @@
         }
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
@@ -502,50 +456,38 @@
       }
     },
     "ts-node": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
-      "integrity": "sha1-NtlSnHuQu5kzBsQIzQf3dD3iBxI=",
+      "version": "10.9.1",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "chalk": "^2.3.0",
-        "diff": "^3.1.0",
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.0",
-        "tsconfig": "^7.0.0",
-        "v8flags": "^3.0.0",
-        "yn": "^2.0.0"
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
       }
     },
-    "tsconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha1-hFOIdaTcIW5cSlQys6Tew9VOkbc=",
-      "dev": true,
-      "requires": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -554,9 +496,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "4.8.3",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
     },
     "uuid": {
@@ -565,14 +507,11 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
-    "v8flags": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
-      "integrity": "sha1-skPjtN/XMfp3TnSSEoEJoP5m1lY=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "^1.0.1"
-      }
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
@@ -597,9 +536,9 @@
       "dev": true
     },
     "yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "version": "3.1.1",
+      "resolved": "https://repo.aeb.com/artifactory/api/npm/npm/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,21 +24,20 @@
     "postpublish": ""
   },
   "dependencies": {
-    "graphql-iso-date": "~3.3.0"
+    "graphql-scalars": "^1.18.0"
   },
   "peerDependencies": {
-    "graphql": "~0.10.0 | ~0.11.0 | ~0.12.0",
+    "graphql": "^15.0.0 || ^16.0.0",
     "soap": "~0.43.0"
   },
   "devDependencies": {
-    "@types/graphql": "~0.12.3",
-    "@types/node": "^8.0.0",
+    "@types/node": "^14.14.31",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "graphql": "~0.12.0",
+    "graphql": "^16.6.0",
     "mocha": "^4.0.1",
     "soap": "^0.43.0",
-    "ts-node": "~4.1.0",
-    "typescript": "~2.6.2"
+    "ts-node": "^10.9.1",
+    "typescript": "~4.8.3"
   }
 }

--- a/spec/node-soap-graphql.spec.ts
+++ b/spec/node-soap-graphql.spec.ts
@@ -3,7 +3,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import { expect } from 'chai';
 import { after, afterEach, before, beforeEach, describe, fail, it, xit } from 'mocha';
 import { GraphQLSchema } from 'graphql/type/schema';
-import { introspectionQuery } from 'graphql/utilities/introspectionQuery';
+import { getIntrospectionQuery } from 'graphql';
 import { graphql, printSchema, GraphQLInputType, GraphQLEnumType, GraphQLEnumValueConfigMap } from 'graphql';
 import { inspect } from 'util';
 import { GraphQLBoolean } from 'graphql/type/scalars';
@@ -215,26 +215,32 @@ describe('call soap endpoints', () => {
         // console.log(`schema`, printSchema(schema));
 
         // check that intorspection can be executed
-        const introspection = await graphql(schema, introspectionQuery);
+        const introspection = await graphql({ schema, source: getIntrospectionQuery() });
         // console.log(`introspection`, introspection);
         expect(introspection).to.exist;
 
         // check the description field
-        const description = await graphql(schema, `
-            {
-                description
-            }
-        `);
+        const description = await graphql({
+            schema,
+            source: `
+                {
+                    description
+                }
+            `
+        });
         // console.log(`description`, description);
         expect(description).to.exist;
 
-        const errorRes = await graphql(schema, `
-            mutation {
-                foo {
-                    bar
+        const errorRes = await graphql({
+            schema,
+            source: `
+                mutation {
+                    foo {
+                        bar
+                    }
                 }
-            }
-        `);
+            `
+        });
         // console.log(`error'`, errorRes);
         expect(errorRes).to.exist;
         expect(errorRes.data).to.not.exist;
@@ -247,7 +253,7 @@ describe('call soap endpoints', () => {
 
         const schema: GraphQLSchema = await callEndpoint(options);
 
-        const res: any = await graphql(schema, query);
+        const res: any = await graphql({ schema, source: query });
         // console.log(`result`, res);
         expect(res).to.exist;
         expect(res.data).to.exist;

--- a/spec/src/soap2graphql/default-type-resolver.spec.ts
+++ b/spec/src/soap2graphql/default-type-resolver.spec.ts
@@ -3,7 +3,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import { expect } from 'chai';
 import { after, afterEach, before, beforeEach, describe, fail, it } from 'mocha';
 import { GraphQLInt, GraphQLString, GraphQLBoolean, GraphQLFloat, GraphQLID } from 'graphql/type/scalars';
-import { GraphQLDateTime, GraphQLTime, GraphQLDate } from 'graphql-iso-date';
+import { GraphQLDateTime, GraphQLTime, GraphQLDate } from 'graphql-scalars';
 import { DefaultTypeResolver } from '../../../src/soap2graphql/custom-type-resolver';
 
 chai.use(chaiAsPromised);
@@ -41,11 +41,11 @@ describe('DefaultTypeResolver', () => {
         expect(resolver.resolve('IDREFS')).to.equal(GraphQLString);
         expect(resolver.resolve('ENTITY')).to.equal(GraphQLString);
         expect(resolver.resolve('ENTITIES')).to.equal(GraphQLString);
-        
+
         expect(resolver.resolve('ID')).to.equal(GraphQLID);
-        
+
         expect(resolver.resolve('boolean')).to.equal(GraphQLBoolean);
-        
+
         expect(resolver.resolve('byte')).to.equal(GraphQLInt);
         expect(resolver.resolve('unsignedByte')).to.equal(GraphQLInt);
         expect(resolver.resolve('short')).to.equal(GraphQLInt);
@@ -59,11 +59,11 @@ describe('DefaultTypeResolver', () => {
         expect(resolver.resolve('nonNegativeInteger')).to.equal(GraphQLInt);
         expect(resolver.resolve('long')).to.equal(GraphQLInt);
         expect(resolver.resolve('unsignedLong')).to.equal(GraphQLInt);
-        
+
         expect(resolver.resolve('decimal')).to.equal(GraphQLFloat);
         expect(resolver.resolve('float')).to.equal(GraphQLFloat);
         expect(resolver.resolve('double')).to.equal(GraphQLFloat);
-        
+
         expect(resolver.resolve('dateTime')).to.equal(GraphQLDateTime);
         expect(resolver.resolve('date')).to.equal(GraphQLDate);
         expect(resolver.resolve('time')).to.equal(GraphQLTime);

--- a/spec/src/soap2graphql/name-resolver.spec.ts
+++ b/spec/src/soap2graphql/name-resolver.spec.ts
@@ -12,18 +12,18 @@ describe('name-resolver', () => {
 
         expect(defaultOutputNameResolver(null)).to.not.exist;
         expect(defaultOutputNameResolver(undefined)).to.not.exist;
-        expect(defaultOutputNameResolver({ name: null })).to.not.exist;
-        expect(defaultOutputNameResolver({ name: undefined })).to.not.exist;
-        expect(defaultOutputNameResolver({ name: '' })).to.not.exist;
+        expect(defaultOutputNameResolver({ name: null } as any)).to.not.exist;
+        expect(defaultOutputNameResolver({ name: undefined } as any)).to.not.exist;
+        expect(defaultOutputNameResolver({ name: '' } as any)).to.not.exist;
 
-        expect(defaultOutputNameResolver({ name: 'a' })).to.equal('A');
-        expect(defaultOutputNameResolver({ name: 'A' })).to.equal('A');
+        expect(defaultOutputNameResolver({ name: 'a' } as any)).to.equal('A');
+        expect(defaultOutputNameResolver({ name: 'A' } as any)).to.equal('A');
 
-        expect(defaultOutputNameResolver({ name: 'ab' })).to.equal('Ab');
-        expect(defaultOutputNameResolver({ name: 'Ab' })).to.equal('Ab');
+        expect(defaultOutputNameResolver({ name: 'ab' } as any)).to.equal('Ab');
+        expect(defaultOutputNameResolver({ name: 'Ab' } as any)).to.equal('Ab');
 
-        expect(defaultOutputNameResolver({ name: 'abc' })).to.equal('Abc');
-        expect(defaultOutputNameResolver({ name: 'Abc' })).to.equal('Abc');
+        expect(defaultOutputNameResolver({ name: 'abc' } as any)).to.equal('Abc');
+        expect(defaultOutputNameResolver({ name: 'Abc' } as any)).to.equal('Abc');
 
     }).timeout(10000);
 
@@ -31,18 +31,18 @@ describe('name-resolver', () => {
 
         expect(defaultInterfaceNameResolver(null)).to.not.exist;
         expect(defaultInterfaceNameResolver(undefined)).to.not.exist;
-        expect(defaultInterfaceNameResolver({ name: null })).to.not.exist;
-        expect(defaultInterfaceNameResolver({ name: undefined })).to.not.exist;
-        expect(defaultOutputNameResolver({ name: '' })).to.not.exist;
+        expect(defaultInterfaceNameResolver({ name: null } as any)).to.not.exist;
+        expect(defaultInterfaceNameResolver({ name: undefined } as any)).to.not.exist;
+        expect(defaultOutputNameResolver({ name: '' } as any)).to.not.exist;
 
-        expect(defaultInterfaceNameResolver({ name: 'a' })).to.equal('iA');
-        expect(defaultInterfaceNameResolver({ name: 'A' })).to.equal('iA');
+        expect(defaultInterfaceNameResolver({ name: 'a' } as any)).to.equal('iA');
+        expect(defaultInterfaceNameResolver({ name: 'A' } as any)).to.equal('iA');
 
-        expect(defaultInterfaceNameResolver({ name: 'ab' })).to.equal('iAb');
-        expect(defaultInterfaceNameResolver({ name: 'Ab' })).to.equal('iAb');
+        expect(defaultInterfaceNameResolver({ name: 'ab' } as any)).to.equal('iAb');
+        expect(defaultInterfaceNameResolver({ name: 'Ab' } as any)).to.equal('iAb');
 
-        expect(defaultInterfaceNameResolver({ name: 'abc' })).to.equal('iAbc');
-        expect(defaultInterfaceNameResolver({ name: 'Abc' })).to.equal('iAbc');
+        expect(defaultInterfaceNameResolver({ name: 'abc' } as any)).to.equal('iAbc');
+        expect(defaultInterfaceNameResolver({ name: 'Abc' } as any)).to.equal('iAbc');
 
     }).timeout(10000);
 
@@ -50,18 +50,18 @@ describe('name-resolver', () => {
 
         expect(defaultInputNameResolver(null)).to.not.exist;
         expect(defaultInputNameResolver(undefined)).to.not.exist;
-        expect(defaultInputNameResolver({ name: null })).to.not.exist;
-        expect(defaultInputNameResolver({ name: undefined })).to.not.exist;
-        expect(defaultInputNameResolver({ name: '' })).to.not.exist;
+        expect(defaultInputNameResolver({ name: null } as any)).to.not.exist;
+        expect(defaultInputNameResolver({ name: undefined } as any)).to.not.exist;
+        expect(defaultInputNameResolver({ name: '' } as any)).to.not.exist;
 
-        expect(defaultInputNameResolver({ name: 'a' })).to.equal('AInput');
-        expect(defaultInputNameResolver({ name: 'A' })).to.equal('AInput');
+        expect(defaultInputNameResolver({ name: 'a' } as any)).to.equal('AInput');
+        expect(defaultInputNameResolver({ name: 'A' } as any)).to.equal('AInput');
 
-        expect(defaultInputNameResolver({ name: 'ab' })).to.equal('AbInput');
-        expect(defaultInputNameResolver({ name: 'Ab' })).to.equal('AbInput');
+        expect(defaultInputNameResolver({ name: 'ab' } as any)).to.equal('AbInput');
+        expect(defaultInputNameResolver({ name: 'Ab' } as any)).to.equal('AbInput');
 
-        expect(defaultInputNameResolver({ name: 'abc' })).to.equal('AbcInput');
-        expect(defaultInputNameResolver({ name: 'Abc' })).to.equal('AbcInput');
+        expect(defaultInputNameResolver({ name: 'abc' } as any)).to.equal('AbcInput');
+        expect(defaultInputNameResolver({ name: 'Abc' } as any)).to.equal('AbcInput');
 
     }).timeout(10000);
 

--- a/src/soap2graphql/custom-type-resolver.ts
+++ b/src/soap2graphql/custom-type-resolver.ts
@@ -1,10 +1,10 @@
 import { GraphQLScalarType, GraphQLID, GraphQLString, GraphQLFloat, GraphQLBoolean, GraphQLInt, GraphQLOutputType, GraphQLInputType } from 'graphql';
-import { GraphQLDateTime, GraphQLTime, GraphQLDate } from 'graphql-iso-date';
+import { GraphQLDateTime, GraphQLTime, GraphQLDate } from 'graphql-scalars';
 
 /**
  * Resolver that converts WSDL types, that are not fully defined in the WSDL itself, to GraphQL types.
  * This is especially necessary for all primitive WSDL types (resp. scalar GraphQL types) like 'string', 'datetime', etc.
- * 
+ *
  * You can provide your own resolver to handle custom types of your WSDL.
  * But you must still provide resolvment for primitive types like 'string', e.g by re-using DefaultTypeResolver.
  */

--- a/src/soap2graphql/schema-resolver.ts
+++ b/src/soap2graphql/schema-resolver.ts
@@ -6,7 +6,7 @@ import { GraphQLString } from 'graphql/type/scalars';
 import { SoapEndpoint, SoapService, SoapPort, SoapOperation, SoapField, SoapType, SoapObjectType, SoapOperationArg } from './soap-endpoint';
 import { SoapCaller } from './soap-caller';
 import { inspect } from 'util';
-import { GraphQLObjectType, Thunk, GraphQLFieldConfigMap, GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLOutputType, GraphQLFieldResolver, GraphQLNonNull, GraphQLResolveInfo, GraphQLInterfaceType, GraphQLList, GraphQLScalarType, GraphQLObjectTypeConfig, GraphQLInterfaceTypeConfig, GraphQLInputType, GraphQLInputObjectType, GraphQLInputObjectTypeConfig, GraphQLInputFieldConfigMap } from 'graphql';
+import { GraphQLObjectType, GraphQLFieldConfigMap, GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLOutputType, GraphQLFieldResolver, GraphQLNonNull, GraphQLResolveInfo, GraphQLInterfaceType, GraphQLList, GraphQLScalarType, GraphQLObjectTypeConfig, GraphQLInterfaceTypeConfig, GraphQLInputType, GraphQLInputObjectType, GraphQLInputObjectTypeConfig, GraphQLInputFieldConfigMap } from 'graphql';
 import { Logger } from './logger';
 
 export class SchemaResolver {
@@ -67,7 +67,7 @@ export class SchemaResolver {
 
     createMutationObject(): GraphQLObjectType {
 
-        const fieldsThunk: Thunk<GraphQLFieldConfigMap<any, any>> = () => {
+        const fieldsThunk = (): GraphQLFieldConfigMap<any, any> => {
             const fields: GraphQLFieldConfigMap<any, any> = {};
 
             this.soapEndpoint.services().forEach((service: SoapService) => {
@@ -97,7 +97,7 @@ export class SchemaResolver {
 
     createSoapServiceField(service: SoapService): GraphQLFieldConfig<any, any> {
 
-        const fieldsThunk: Thunk<GraphQLFieldConfigMap<any, any>> = () => {
+        const fieldsThunk = (): GraphQLFieldConfigMap<any, any> => {
             const fields: GraphQLFieldConfigMap<any, any> = {};
 
             service.ports().forEach((port: SoapPort) => {
@@ -128,7 +128,7 @@ export class SchemaResolver {
 
     createSoapPortField(service: SoapService, port: SoapPort): GraphQLFieldConfig<any, any> {
 
-        const fieldsThunk: Thunk<GraphQLFieldConfigMap<any, any>> = () => {
+        const fieldsThunk = (): GraphQLFieldConfigMap<any, any> => {
             const fields: GraphQLFieldConfigMap<any, any> = {};
 
             port.operations().forEach((operation: SoapOperation) => {
@@ -241,13 +241,13 @@ class GraphqlOutputFieldResolver {
 
     private createObjectTypeConfig(soapType: SoapObjectType): GraphQLObjectTypeConfig<any, any> {
 
-        const fields: Thunk<GraphQLFieldConfigMap<any, any>> = () => {
+        const fields = (): GraphQLFieldConfigMap<any, any> => {
             const fieldMap: GraphQLFieldConfigMap<any, any> = {};
             this.appendObjectTypeFields(fieldMap, soapType);
             return fieldMap;
         };
 
-        const interfaces: Thunk<GraphQLInterfaceType[]> = () => {
+        const interfaces = (): GraphQLInterfaceType[] => {
             const interfaces: GraphQLInterfaceType[] = [];
             this.appendInterfaces(interfaces, soapType);
             return interfaces;
@@ -295,7 +295,7 @@ class GraphqlOutputFieldResolver {
 
     private createInterfaceTypeConfig(soapType: SoapObjectType): GraphQLInterfaceTypeConfig<any, any> {
 
-        const fields: Thunk<GraphQLFieldConfigMap<any, any>> = () => {
+        const fields = (): GraphQLFieldConfigMap<any, any> => {
             const fieldMap: GraphQLFieldConfigMap<any, any> = {};
             this.appendInterfaceTypeFields(fieldMap, soapType);
             return fieldMap;
@@ -371,7 +371,7 @@ class GraphqlInputFieldResolver {
 
     private createObjectTypeConfig(soapType: SoapObjectType): GraphQLInputObjectTypeConfig {
 
-        const fields: Thunk<GraphQLInputFieldConfigMap> = () => {
+        const fields = (): GraphQLInputFieldConfigMap => {
             const fieldMap: GraphQLInputFieldConfigMap = {};
             this.appendObjectTypeFields(fieldMap, soapType);
             return fieldMap;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,13 @@
     "compilerOptions": {
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es5",
+        "target": "ES2020",
         "noImplicitAny": false,
         "sourceMap": true,
         "declaration": true,
         "removeComments": false,
         "lib": [
-            "es2017",
-            "esnext.asynciterable"
+            "ES2020",
         ],
         "typeRoots": [
             "node_modules/@types"


### PR DESCRIPTION
Now requires node 14. We could drop this dependency, but node < 14 is EOL anyway and this makes the generated js files nicer because they can use more modern JS features.

I also restricted graphql to 15 and 16 because it's probably pretty easy to rely on more modern features now that graphql is updated to 16 in this repo.

Both breaking changes could be undone, but maybe a release 2.0 is not so bad?